### PR TITLE
Ensure stale connections are closed.

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,10 @@ func CreateServer(config *config.Config, listener net.Listener, syncServer proto
 			MinTime:             time.Second * 5,
 			PermitWithoutStream: true,
 		}),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    time.Second * 10,
+			Timeout: time.Second * 5,
+		}),
 	)
 	proto.RegisterSyncerServer(s, syncServer)
 	return s


### PR DESCRIPTION
Before this change stale connections were held for 2 hours before the server closed them which probably caused it to reject new connections at some point.
We fix this by ensuring keep alive every 10 seconds.