### PR TITLE
Fix hang

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -21,15 +21,11 @@ cpus = 1
 [[services]]
 internal_port = 8080
 protocol = "tcp"
-min_machines_running = 2
+min_machines_running = 1
+auto_start_machines = false
 processes = ['app']
 
 [[services.ports]]
 handlers = ["tls"]
 port = 443
 tls_options = { "alpn" = ["h2"] }
-
-[services.concurrency]
-type = "connections"
-hard_limit = 1000
-soft_limit = 500


### PR DESCRIPTION
This PR fixes a hang that occurs after several hours of running.
The origin of this is the initial notification on subscribing. Since it was executed within the event loop then it hanged on cases where there was non listener for the channel.
This cases were rare but they happened when the client attempted to subscribe and then immediately unsubscribe before the first notification was sent.
I moved the notification into the streaming loop.
Also added a mutex lock for incrementing global ids.