### PR TITLE
Add user-agent logging to syncer server endpoints

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -21,6 +21,7 @@ import (
 const (
 	USER_PUBKEY_CONTEXT_KEY  = "user_pubkey"
 	API_KEY_HASH_CONTEXT_KEY = "api_key_hash"
+	USER_AGENT_CONTEXT_KEY   = "user_agent"
 )
 
 var ErrInternalError = fmt.Errorf("internal error")
@@ -124,6 +125,13 @@ func Authenticate(config *config.Config, ctx context.Context, req interface{}) (
 		apiKeyHash = hex.EncodeToString(h[:])
 	}
 	newContext = context.WithValue(newContext, API_KEY_HASH_CONTEXT_KEY, apiKeyHash)
+	userAgent := ""
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if ua := md.Get("user-agent"); len(ua) > 0 {
+			userAgent = ua[0]
+		}
+	}
+	newContext = context.WithValue(newContext, USER_AGENT_CONTEXT_KEY, userAgent)
 	return newContext, nil
 }
 

--- a/syncer_server.go
+++ b/syncer_server.go
@@ -111,7 +111,8 @@ func (s *PersistentSyncerServer) SetRecord(ctx context.Context, msg *proto.SetRe
 	}
 	pubkey := c.Value(middleware.USER_PUBKEY_CONTEXT_KEY).(string)
 	apiKeyHash := c.Value(middleware.API_KEY_HASH_CONTEXT_KEY).(string)
-	log.Printf("SetRecord: pubkey: %v, api_key_hash: %v\n", pubkey, apiKeyHash)
+	userAgent := c.Value(middleware.USER_AGENT_CONTEXT_KEY).(string)
+	log.Printf("SetRecord: pubkey: %v, api_key_hash: %v, user_agent: %v\n", pubkey, apiKeyHash, userAgent)
 	newRevision, err := s.storage.SetRecord(c, pubkey, msg.Record.Id, msg.Record.Data, msg.Record.Revision, msg.Record.SchemaVersion)
 
 	if err != nil {
@@ -144,7 +145,8 @@ func (s *PersistentSyncerServer) ListChanges(ctx context.Context, msg *proto.Lis
 	}
 	pubkey := c.Value(middleware.USER_PUBKEY_CONTEXT_KEY).(string)
 	apiKeyHash := c.Value(middleware.API_KEY_HASH_CONTEXT_KEY).(string)
-	log.Printf("ListChanges: pubkey: %v, api_key_hash: %v\n", pubkey, apiKeyHash)
+	userAgent := c.Value(middleware.USER_AGENT_CONTEXT_KEY).(string)
+	log.Printf("ListChanges: pubkey: %v, api_key_hash: %v, user_agent: %v\n", pubkey, apiKeyHash, userAgent)
 	changed, err := s.storage.ListChanges(c, pubkey, msg.SinceRevision, maxListChangesLimit)
 	if err != nil {
 		return nil, err
@@ -256,7 +258,8 @@ func (s *PersistentSyncerServer) SetLock(ctx context.Context, msg *proto.SetLock
 	}
 	pubkey := c.Value(middleware.USER_PUBKEY_CONTEXT_KEY).(string)
 	apiKeyHash := c.Value(middleware.API_KEY_HASH_CONTEXT_KEY).(string)
-	log.Printf("SetLock: pubkey: %v, api_key_hash: %v, lock_name: %v, acquire: %v\n", pubkey, apiKeyHash, msg.LockName, msg.Acquire)
+	userAgent := c.Value(middleware.USER_AGENT_CONTEXT_KEY).(string)
+	log.Printf("SetLock: pubkey: %v, api_key_hash: %v, user_agent: %v, lock_name: %v, acquire: %v\n", pubkey, apiKeyHash, userAgent, msg.LockName, msg.Acquire)
 
 	ttl := defaultLockTTLSeconds
 	if msg.TtlSeconds != nil {
@@ -292,7 +295,8 @@ func (s *PersistentSyncerServer) GetLock(ctx context.Context, msg *proto.GetLock
 	}
 	pubkey := c.Value(middleware.USER_PUBKEY_CONTEXT_KEY).(string)
 	apiKeyHash := c.Value(middleware.API_KEY_HASH_CONTEXT_KEY).(string)
-	log.Printf("GetLock: pubkey: %v, api_key_hash: %v, lock_name: %v\n", pubkey, apiKeyHash, msg.LockName)
+	userAgent := c.Value(middleware.USER_AGENT_CONTEXT_KEY).(string)
+	log.Printf("GetLock: pubkey: %v, api_key_hash: %v, user_agent: %v, lock_name: %v\n", pubkey, apiKeyHash, userAgent, msg.LockName)
 
 	locked, err := s.storage.HasActiveLock(c, pubkey, msg.LockName)
 	if err != nil {


### PR DESCRIPTION
## Summary
This PR adds user-agent tracking and logging to the syncer server by extracting the user-agent from incoming gRPC request metadata and including it in log messages across multiple endpoints.

## Key Changes
- Added `USER_AGENT_CONTEXT_KEY` constant to middleware/auth.go for storing user-agent in request context
- Updated `Authenticate()` middleware to extract user-agent from gRPC metadata and store it in the request context
- Enhanced logging in four syncer server endpoints to include user-agent information:
  - `SetRecord()`: Added user-agent to log output
  - `ListChanges()`: Added user-agent to log output
  - `SetLock()`: Added user-agent to log output
  - `GetLock()`: Added user-agent to log output

## Implementation Details
- User-agent is extracted from the `user-agent` header in gRPC incoming metadata
- If the header is not present, an empty string is used as the default value
- The user-agent is stored in the request context alongside existing pubkey and api_key_hash values
- All affected log statements now include the user-agent for better request traceability and debugging

https://claude.ai/code/session_017f6RdGyBaoGAUNSi1q1r68