### PR TITLE
Add support for x-user-agent header in authentication

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -127,7 +127,9 @@ func Authenticate(config *config.Config, ctx context.Context, req interface{}) (
 	newContext = context.WithValue(newContext, API_KEY_HASH_CONTEXT_KEY, apiKeyHash)
 	userAgent := ""
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if ua := md.Get("user-agent"); len(ua) > 0 {
+		if xua := md.Get("x-user-agent"); len(xua) > 0 {
+			userAgent = xua[0]
+		} else if ua := md.Get("user-agent"); len(ua) > 0 {
 			userAgent = ua[0]
 		}
 	}


### PR DESCRIPTION
## Summary
Updated the authentication middleware to prioritize the `x-user-agent` header over the standard `user-agent` header when extracting user agent information from incoming requests.

## Key Changes
- Modified the user agent extraction logic in `Authenticate()` to check for `x-user-agent` header first
- Falls back to the standard `user-agent` header if `x-user-agent` is not present
- This allows clients to explicitly specify a custom user agent via the `x-user-agent` header while maintaining backward compatibility

## Implementation Details
- The change uses a conditional chain: first attempts to retrieve `x-user-agent`, and only if that's empty/missing, falls back to `user-agent`
- Both headers are checked using the same validation pattern (checking if the metadata slice has length > 0)
- No changes to the context key or other authentication logic

https://claude.ai/code/session_01LC3zb6DfTeKefcr9umyXLp